### PR TITLE
CN/13-Remove-Blog

### DIFF
--- a/TabloidCLI/UserInterfaceManagers/BlogManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/BlogManager.cs
@@ -70,6 +70,7 @@ namespace TabloidCLI.UserInterfaceManagers
             }
         }
 
+        //used in Edit and Remove, and to view Blog Detail Menu
         private Blog Choose(string prompt = null)
         {
             if (prompt == null)
@@ -81,6 +82,7 @@ namespace TabloidCLI.UserInterfaceManagers
 
             List<Blog> blogs = _blogRepository.GetAll();
 
+            //display blogs for user to choose from
             for (int i = 0; i < blogs.Count; i++)
             {
                 Blog blog = blogs[i];
@@ -91,6 +93,7 @@ namespace TabloidCLI.UserInterfaceManagers
             string input = Console.ReadLine();
             try
             {
+                //convert user choise to list index
                 int choice = int.Parse(input);
                 return blogs[choice - 1];
             }


### PR DESCRIPTION
# Description

Added functionality to remove a blog from the database.

***Given*** the user is viewing the Blog Management menu
***When*** they select the option to remove a blog
***Then*** they should be presented with a list of blogs to choose from

***Given*** the user chooses an blog
***When*** they enter the selection and hit enter
***Then*** the blog should be removed from the database


# Testing Instructions

1. From the Blog Management menu, add a new blog if you would rather not loose any of the seed data
2. After you're back at the blog management menu, choose option 5 for Remove Blog
3. It may take a minute for the list of blogs to load
4. Select the one you'd like to delete
5. Back at the blog management menu, select 1 to view the list of blogs
6. The blog you deleted should be gone from the list


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
