### PR TITLE
Add and View author tags

### DIFF
--- a/TabloidCLI/Repositories/AuthorRepository.cs
+++ b/TabloidCLI/Repositories/AuthorRepository.cs
@@ -123,6 +123,8 @@ namespace TabloidCLI
                 conn.Open();
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
+
+                    //     INCLUDE LEFT JOIN ?? FOR AUTHOR TAG?
                     cmd.CommandText = @"UPDATE Author 
                                            SET FirstName = @firstName,
                                                LastName = @lastName,


### PR DESCRIPTION
Given the user is viewing the Author Details menu
When they select the option to add a tag
Then they should be presented with a list of available tags to choose from

Given the user chooses a tag
When they enter the selection and hit enter
Then the relationship between the tag and the author should be saved to the database



Testing

View Author Details Menu, next view and add Tags to individual authors




# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
