### PR TITLE
Searching authors

### DIFF
--- a/TabloidCLI/Repositories/AuthorRepository.cs
+++ b/TabloidCLI/Repositories/AuthorRepository.cs
@@ -123,6 +123,8 @@ namespace TabloidCLI
                 conn.Open();
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
+
+                    //     INCLUDE LEFT JOIN ?? FOR AUTHOR TAG?
                     cmd.CommandText = @"UPDATE Author 
                                            SET FirstName = @firstName,
                                                LastName = @lastName,


### PR DESCRIPTION
Given the user is on the search menu
When they select the search authrs option
Then they should be prompted to enter a tag name

Given the suer enters a tag name
When there is no author that matches the tag name
Then the user should be informed that no search results were found

Given the user enters a tag name
When there is one or more authors that match the tag name
Then the authors should be displayed


# Testing Instructions

from main menu go to search by tag
search authors
type in an existing tag first
then type in a tag that doesnt exist in database.



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
