### PR TITLE
SB/26-Post-Details

### DIFF
--- a/TabloidCLI/Repositories/PostRepository.cs
+++ b/TabloidCLI/Repositories/PostRepository.cs
@@ -73,7 +73,7 @@ namespace TabloidCLI.Repositories
                 conn.Open();
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = @"@""SELECT p.id,
+                    cmd.CommandText = @"SELECT p.id,
                                                p.Title As PostTitle,
                                                p.URL AS PostUrl,
                                                p.PublishDateTime,

--- a/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TabloidCLI.Models;
+using TabloidCLI.Repositories;
+
+namespace TabloidCLI.UserInterfaceManagers
+{
+    internal class PostDetailManager : IUserInterfaceManager
+    {
+        private IUserInterfaceManager _parentUI;
+        private PostRepository _postRepository;
+        private TagRepository _tagRepository;
+        private int _postId;
+
+        public PostDetailManager(IUserInterfaceManager parentUI, string connectionString, int postId)
+        {
+            _parentUI = parentUI;
+            _postRepository = new PostRepository(connectionString);
+            _tagRepository = new TagRepository(connectionString);
+            _postId = postId;
+        }
+
+        public IUserInterfaceManager Execute()
+        {
+            Post post = _postRepository.Get(_postId);
+            Console.WriteLine($"{post.Title} Details");
+            Console.WriteLine(" 1) View");
+            Console.WriteLine(" 2) Add Tag");
+            Console.WriteLine(" 3) Remove Tag");
+            Console.WriteLine(" 4) Note Management");
+            Console.WriteLine(" 0) Go Back");
+
+            Console.Write("> ");
+            string choice = Console.ReadLine();
+            switch (choice)
+            {
+                case "1":
+                    View();
+                    return this;
+                case "2":
+                    AddTag();
+                    return this;
+                case "3":
+                    RemoveTag();
+                    return this;
+                case "4":
+                    throw new NotImplementedException();
+                    //return new NoteManager(this, _connectionString, post.Id);
+                case "0":
+                    return _parentUI;
+                default:
+                    Console.WriteLine("Invalid Selection");
+                    return this;
+            }
+        }
+
+        private void View()
+        {
+            Post post = _postRepository.Get(_postId);
+            Console.WriteLine($"Title: {post.Title}");
+            Console.WriteLine($"URL: {post.Url}");
+            Console.WriteLine($"Publication Date: {post.PublishDateTime}");
+
+            //Console.WriteLine("Tags:");
+            //foreach (Tag tag in post.Tags)
+            //{
+            //    Console.WriteLine(" " + tag);
+            //}
+            //Console.WriteLine();
+        }
+
+        private void AddTag()
+        {
+            throw new NotImplementedException();
+            //Post post = _postRepository.Get(_postId);
+
+            //Console.WriteLine($"Which tag would you like to add to {post.Title}?");
+            //List<Tag> tags = _tagRepository.GetAll();
+
+            //for (int i = 0; i < tags.Count; i++)
+            //{
+            //    Tag tag = tags[i];
+            //    Console.WriteLine($" {i + 1}) {tag.Name}");
+            //}
+            //Console.Write("> ");
+
+            //string input = Console.ReadLine();
+            //try
+            //{
+            //    int choice = int.Parse(input);
+            //    Tag tag = tags[choice - 1];
+            //    _postRepository.InsertTag(post, tag);
+            //}
+            //catch (Exception ex)
+            //{
+            //    Console.WriteLine("Invalid Selection. Won't add any tags.");
+            //}
+        }
+
+        private void RemoveTag()
+        {
+            throw new NotImplementedException();
+            //Post post = _postRepository.Get(_postId);
+
+            //Console.WriteLine($"Which tag would you like to remove from {post.Title}?");
+            //List<Tag> tags = post.Tags;
+
+            //for (int i = 0; i < tags.Count; i++)
+            //{
+            //    Tag tag = tags[i];
+            //    Console.WriteLine($" {i + 1}) {tag.Name}");
+            //}
+            //Console.Write("> ");
+
+            //string input = Console.ReadLine();
+            //try
+            //{
+            //    int choice = int.Parse(input);
+            //    Tag tag = tags[choice - 1];
+            //    _postRepository.DeleteTag(post.Id, tag.Id);
+            //}
+            //catch (Exception ex)
+            //{
+            //    Console.WriteLine("Invalid Selection. Won't remove any tags.");
+            //}
+        }
+    }
+}

--- a/TabloidCLI/UserInterfaceManagers/PostManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostManager.cs
@@ -49,8 +49,7 @@ namespace TabloidCLI.UserInterfaceManagers
                     }
                     else
                     {
-                        //return new PostDetailManager(this, _connectionString, post.Id);
-                        throw new NotImplementedException();
+                        return new PostDetailManager(this, _connectionString, post.Id);
                     }
                 case "3":
                     Add();


### PR DESCRIPTION
# Description

PR adds the ability to view details of a post via post details menu as outlined in [Issue #26](https://trello.com/c/ZHz5f4Ug/26-post-details-26)


# Testing Instructions

From the SB/26-Post-Details branch:

_Given_ the user is viewing the Post Management menu
_When_ they select the option to view post details
_Then_ they should be presented with a list of posts to choose from

_Given_ the user chooses a post
_When_ they enter the selection and hit enter
_Then_ the Post Details menu should be displayed

_Given_ the user wishes to view the post details
_When_ they select "View"
_Then_ the post's title, url and publication date should be displayed

You should also be able to return to the Post Management menu from the Post Details menu.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
