### PR TITLE
SB/34-View-Posts-Tags

### DIFF
--- a/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
@@ -74,30 +74,29 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void AddTag()
         {
-            throw new NotImplementedException();
-            //Post post = _postRepository.Get(_postId);
+            Post post = _postRepository.Get(_postId);
 
-            //Console.WriteLine($"Which tag would you like to add to {post.Title}?");
-            //List<Tag> tags = _tagRepository.GetAll();
+            Console.WriteLine($"Which tag would you like to add to {post.Title}?");
+            List<Tag> tags = _tagRepository.GetAll();
 
-            //for (int i = 0; i < tags.Count; i++)
-            //{
-            //    Tag tag = tags[i];
-            //    Console.WriteLine($" {i + 1}) {tag.Name}");
-            //}
-            //Console.Write("> ");
+            for (int i = 0; i < tags.Count; i++)
+            {
+                Tag tag = tags[i];
+                Console.WriteLine($" {i + 1}) {tag.Name}");
+            }
+            Console.Write("> ");
 
-            //string input = Console.ReadLine();
-            //try
-            //{
-            //    int choice = int.Parse(input);
-            //    Tag tag = tags[choice - 1];
-            //    _postRepository.InsertTag(post, tag);
-            //}
-            //catch (Exception ex)
-            //{
-            //    Console.WriteLine("Invalid Selection. Won't add any tags.");
-            //}
+            string input = Console.ReadLine();
+            try
+            {
+                int choice = int.Parse(input);
+                Tag tag = tags[choice - 1];
+                _postRepository.InsertTag(post, tag);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Invalid Selection. Won't add any tags.");
+            }
         }
 
         private void RemoveTag()

--- a/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
@@ -64,12 +64,12 @@ namespace TabloidCLI.UserInterfaceManagers
             Console.WriteLine($"URL: {post.Url}");
             Console.WriteLine($"Publication Date: {post.PublishDateTime}");
 
-            //Console.WriteLine("Tags:");
-            //foreach (Tag tag in post.Tags)
-            //{
-            //    Console.WriteLine(" " + tag);
-            //}
-            //Console.WriteLine();
+            Console.WriteLine("Tags:");
+            foreach (Tag tag in post.Tags)
+            {
+                Console.WriteLine(" " + tag);
+            }
+            Console.WriteLine();
         }
 
         private void AddTag()


### PR DESCRIPTION
# Description

PR adds the ability to see the tags for a particular post in the post details menu as outlined in [Issue #34](https://trello.com/c/M1OONdIu/34-view-posts-tags-34)

NOTE: this branch was branched from [SB/33-Add-Tag-to-Post](https://github.com/NewForce-Cohort-6/tabloid-cli-coven-of-the-hallowed-guide/pull/22) and thus includes the ability to add tags to a post. This PR can be used to test and approve BOTH branch PRs.

# Testing Instructions

_Given_ the user is viewing the Post Details menu
_When_ they select the option to view details
_Then_ they should be presented with the list of the post's tags in addition to the post's other information

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
