### PR TITLE
SB/35-Remove-Tag-from-Post

### DIFF
--- a/TabloidCLI/Repositories/PostRepository.cs
+++ b/TabloidCLI/Repositories/PostRepository.cs
@@ -279,5 +279,22 @@ namespace TabloidCLI.Repositories
                 }
             }
         }
+        public void DeleteTag(int postId, int tagId)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"DELETE FROM PostTag 
+                                         WHERE PostId = @postId AND 
+                                               TagId = @tagId";
+                    cmd.Parameters.AddWithValue("@postId", postId);
+                    cmd.Parameters.AddWithValue("@tagId", tagId);
+
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
     }
 }

--- a/TabloidCLI/Repositories/PostRepository.cs
+++ b/TabloidCLI/Repositories/PostRepository.cs
@@ -73,7 +73,7 @@ namespace TabloidCLI.Repositories
                 conn.Open();
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = @"@""SELECT p.id,
+                    cmd.CommandText = @"SELECT p.id,
                                                p.Title As PostTitle,
                                                p.URL AS PostUrl,
                                                p.PublishDateTime,

--- a/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
@@ -74,30 +74,29 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void AddTag()
         {
-            throw new NotImplementedException();
-            //Post post = _postRepository.Get(_postId);
+            Post post = _postRepository.Get(_postId);
 
-            //Console.WriteLine($"Which tag would you like to add to {post.Title}?");
-            //List<Tag> tags = _tagRepository.GetAll();
+            Console.WriteLine($"Which tag would you like to add to {post.Title}?");
+            List<Tag> tags = _tagRepository.GetAll();
 
-            //for (int i = 0; i < tags.Count; i++)
-            //{
-            //    Tag tag = tags[i];
-            //    Console.WriteLine($" {i + 1}) {tag.Name}");
-            //}
-            //Console.Write("> ");
+            for (int i = 0; i < tags.Count; i++)
+            {
+                Tag tag = tags[i];
+                Console.WriteLine($" {i + 1}) {tag.Name}");
+            }
+            Console.Write("> ");
 
-            //string input = Console.ReadLine();
-            //try
-            //{
-            //    int choice = int.Parse(input);
-            //    Tag tag = tags[choice - 1];
-            //    _postRepository.InsertTag(post, tag);
-            //}
-            //catch (Exception ex)
-            //{
-            //    Console.WriteLine("Invalid Selection. Won't add any tags.");
-            //}
+            string input = Console.ReadLine();
+            try
+            {
+                int choice = int.Parse(input);
+                Tag tag = tags[choice - 1];
+                _postRepository.InsertTag(post, tag);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Invalid Selection. Won't add any tags.");
+            }
         }
 
         private void RemoveTag()

--- a/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TabloidCLI.Models;
+using TabloidCLI.Repositories;
+
+namespace TabloidCLI.UserInterfaceManagers
+{
+    internal class PostDetailManager : IUserInterfaceManager
+    {
+        private IUserInterfaceManager _parentUI;
+        private PostRepository _postRepository;
+        private TagRepository _tagRepository;
+        private int _postId;
+
+        public PostDetailManager(IUserInterfaceManager parentUI, string connectionString, int postId)
+        {
+            _parentUI = parentUI;
+            _postRepository = new PostRepository(connectionString);
+            _tagRepository = new TagRepository(connectionString);
+            _postId = postId;
+        }
+
+        public IUserInterfaceManager Execute()
+        {
+            Post post = _postRepository.Get(_postId);
+            Console.WriteLine($"{post.Title} Details");
+            Console.WriteLine(" 1) View");
+            Console.WriteLine(" 2) Add Tag");
+            Console.WriteLine(" 3) Remove Tag");
+            Console.WriteLine(" 4) Note Management");
+            Console.WriteLine(" 0) Go Back");
+
+            Console.Write("> ");
+            string choice = Console.ReadLine();
+            switch (choice)
+            {
+                case "1":
+                    View();
+                    return this;
+                case "2":
+                    AddTag();
+                    return this;
+                case "3":
+                    RemoveTag();
+                    return this;
+                case "4":
+                    throw new NotImplementedException();
+                    //return new NoteManager(this, _connectionString, post.Id);
+                case "0":
+                    return _parentUI;
+                default:
+                    Console.WriteLine("Invalid Selection");
+                    return this;
+            }
+        }
+
+        private void View()
+        {
+            Post post = _postRepository.Get(_postId);
+            Console.WriteLine($"Title: {post.Title}");
+            Console.WriteLine($"URL: {post.Url}");
+            Console.WriteLine($"Publication Date: {post.PublishDateTime}");
+
+            //Console.WriteLine("Tags:");
+            //foreach (Tag tag in post.Tags)
+            //{
+            //    Console.WriteLine(" " + tag);
+            //}
+            //Console.WriteLine();
+        }
+
+        private void AddTag()
+        {
+            throw new NotImplementedException();
+            //Post post = _postRepository.Get(_postId);
+
+            //Console.WriteLine($"Which tag would you like to add to {post.Title}?");
+            //List<Tag> tags = _tagRepository.GetAll();
+
+            //for (int i = 0; i < tags.Count; i++)
+            //{
+            //    Tag tag = tags[i];
+            //    Console.WriteLine($" {i + 1}) {tag.Name}");
+            //}
+            //Console.Write("> ");
+
+            //string input = Console.ReadLine();
+            //try
+            //{
+            //    int choice = int.Parse(input);
+            //    Tag tag = tags[choice - 1];
+            //    _postRepository.InsertTag(post, tag);
+            //}
+            //catch (Exception ex)
+            //{
+            //    Console.WriteLine("Invalid Selection. Won't add any tags.");
+            //}
+        }
+
+        private void RemoveTag()
+        {
+            throw new NotImplementedException();
+            //Post post = _postRepository.Get(_postId);
+
+            //Console.WriteLine($"Which tag would you like to remove from {post.Title}?");
+            //List<Tag> tags = post.Tags;
+
+            //for (int i = 0; i < tags.Count; i++)
+            //{
+            //    Tag tag = tags[i];
+            //    Console.WriteLine($" {i + 1}) {tag.Name}");
+            //}
+            //Console.Write("> ");
+
+            //string input = Console.ReadLine();
+            //try
+            //{
+            //    int choice = int.Parse(input);
+            //    Tag tag = tags[choice - 1];
+            //    _postRepository.DeleteTag(post.Id, tag.Id);
+            //}
+            //catch (Exception ex)
+            //{
+            //    Console.WriteLine("Invalid Selection. Won't remove any tags.");
+            //}
+        }
+    }
+}

--- a/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
@@ -64,12 +64,12 @@ namespace TabloidCLI.UserInterfaceManagers
             Console.WriteLine($"URL: {post.Url}");
             Console.WriteLine($"Publication Date: {post.PublishDateTime}");
 
-            //Console.WriteLine("Tags:");
-            //foreach (Tag tag in post.Tags)
-            //{
-            //    Console.WriteLine(" " + tag);
-            //}
-            //Console.WriteLine();
+            Console.WriteLine("Tags:");
+            foreach (Tag tag in post.Tags)
+            {
+                Console.WriteLine(" " + tag);
+            }
+            Console.WriteLine();
         }
 
         private void AddTag()

--- a/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
@@ -101,30 +101,29 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void RemoveTag()
         {
-            throw new NotImplementedException();
-            //Post post = _postRepository.Get(_postId);
+            Post post = _postRepository.Get(_postId);
 
-            //Console.WriteLine($"Which tag would you like to remove from {post.Title}?");
-            //List<Tag> tags = post.Tags;
+            Console.WriteLine($"Which tag would you like to remove from {post.Title}?");
+            List<Tag> tags = post.Tags;
 
-            //for (int i = 0; i < tags.Count; i++)
-            //{
-            //    Tag tag = tags[i];
-            //    Console.WriteLine($" {i + 1}) {tag.Name}");
-            //}
-            //Console.Write("> ");
+            for (int i = 0; i < tags.Count; i++)
+            {
+                Tag tag = tags[i];
+                Console.WriteLine($" {i + 1}) {tag.Name}");
+            }
+            Console.Write("> ");
 
-            //string input = Console.ReadLine();
-            //try
-            //{
-            //    int choice = int.Parse(input);
-            //    Tag tag = tags[choice - 1];
-            //    _postRepository.DeleteTag(post.Id, tag.Id);
-            //}
-            //catch (Exception ex)
-            //{
-            //    Console.WriteLine("Invalid Selection. Won't remove any tags.");
-            //}
+            string input = Console.ReadLine();
+            try
+            {
+                int choice = int.Parse(input);
+                Tag tag = tags[choice - 1];
+                _postRepository.DeleteTag(post.Id, tag.Id);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Invalid Selection. Won't remove any tags.");
+            }
         }
     }
 }

--- a/TabloidCLI/UserInterfaceManagers/PostManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostManager.cs
@@ -49,8 +49,7 @@ namespace TabloidCLI.UserInterfaceManagers
                     }
                     else
                     {
-                        //return new PostDetailManager(this, _connectionString, post.Id);
-                        throw new NotImplementedException();
+                        return new PostDetailManager(this, _connectionString, post.Id);
                     }
                 case "3":
                     Add();


### PR DESCRIPTION
# Description

Adds the ability to remove a tag from a post in the post details menu as outline in [Issue #35](https://trello.com/c/q9ZgALWP/35-remove-tag-from-post-35)

NOTE: Branched from [SB/34-View-Post-Tags](https://github.com/NewForce-Cohort-6/tabloid-cli-coven-of-the-hallowed-guide/pull/21)

# Testing Instructions

_Given_ the user is viewing the Post Details menu
_When_ they select the option to remove a tag
_Then_ they should be presented with the list of the post's tags in order to choose the tag to remove

_Given_ the user chooses a tag to remove
_When_ they type in the selection and hit enter
_Then_ the relationship between the post and the tag should be removed from the database

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
