### PR TITLE
SB/39-Search-Blogs

### DIFF
--- a/TabloidCLI/Repositories/TagRepository.cs
+++ b/TabloidCLI/Repositories/TagRepository.cs
@@ -104,6 +104,42 @@ namespace TabloidCLI
             }
         }
 
+        public SearchResults<Blog> SearchBlogs(string tagName)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT b.id,
+                                               b.Title,
+                                               b.Url
+                                          FROM Blog b
+                                               LEFT JOIN BlogTag bt on b.Id = bt.BlogId
+                                               LEFT JOIN Tag t on t.Id = bt.TagId
+                                         WHERE t.Name LIKE @name";
+                    cmd.Parameters.AddWithValue("@name", $"%{tagName}%");
+                    SqlDataReader reader = cmd.ExecuteReader();
+
+                    SearchResults<Blog> results = new SearchResults<Blog>();
+                    while (reader.Read())
+                    {
+                        Blog blog = new Blog()
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Title = reader.GetString(reader.GetOrdinal("Title")),
+                            Url = reader.GetString(reader.GetOrdinal("Url")),
+                        };
+                        results.Add(blog);
+                    }
+
+                    reader.Close();
+
+                    return results;
+                }
+            }
+        }
+
         public SearchResults<Author> SearchAuthors(string tagName)
         {
             using (SqlConnection conn = Connection)

--- a/TabloidCLI/UserInterfaceManagers/SearchManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/SearchManager.cs
@@ -28,6 +28,7 @@ namespace TabloidCLI.UserInterfaceManagers
             switch (choice)
             {
                 case "1":
+                    SearchBlogs();
                     return this;
                 case "2":
                     SearchAuthors();
@@ -41,6 +42,23 @@ namespace TabloidCLI.UserInterfaceManagers
                 default:
                     Console.WriteLine("Invalid Selection");
                     return this;
+            }
+        }
+
+        private void SearchBlogs()
+        {
+            Console.WriteLine("Tag> ");
+            string tagName = Console.ReadLine();
+
+            SearchResults<Blog> results = _tagRepository.SearchBlogs(tagName);
+
+            if (results.NoResultsFound)
+            {
+                Console.WriteLine($"No results for {tagName}");
+            }
+            else
+            {
+                results.Display();
             }
         }
 


### PR DESCRIPTION
# Description

PR adds ability to search for blogs by tag as out lined in [Issue #39](https://trello.com/c/U8nYvouW/39-search-blogs-39).


# Testing Instructions

From branch SB/39-Search-Blogs

_Given_ the user is on the search menu
_When_ they select the search blogs option
_Then_ they should be prompted to enter a tag name

_Given_ the user enters a tag name **NOTE**: try "nerdy"
_When_ there is no blog that matches the tag name 
_Then_ the user should be informed that no search results were found

_Given_ the user enters a tag name
_When_ there is one or more blogs that match the tag name
_Then_ the blogs should be displayed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
